### PR TITLE
Implement v7 mapper with caching

### DIFF
--- a/DMapper.ConsoleTests/Benchmarks/ComplexMappingBenchmarks.cs
+++ b/DMapper.ConsoleTests/Benchmarks/ComplexMappingBenchmarks.cs
@@ -72,4 +72,10 @@ public class ComplexMappingBenchmarks
     {
         return ReflectionHelper.ReplacePropertiesRecursive_V6(new ComplexDestination(), _source);
     }
+
+    [Benchmark]
+    public ComplexDestination MapUsingV7()
+    {
+        return ReflectionHelper.ReplacePropertiesRecursive_V7(new ComplexDestination(), _source);
+    }
 }

--- a/DMapper.ConsoleTests/DMapper.ConsoleTests.csproj
+++ b/DMapper.ConsoleTests/DMapper.ConsoleTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>

--- a/DMapper.ConsoleTests/Program.cs
+++ b/DMapper.ConsoleTests/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using BenchmarkDotNet.Running;

--- a/DMapper.Core/DMapper.Core.csproj
+++ b/DMapper.Core/DMapper.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/DMapper.Core/Enums/DMapperVersion.cs
+++ b/DMapper.Core/Enums/DMapperVersion.cs
@@ -8,5 +8,6 @@ public enum DMapperVersion
     V3 = 3,
     V4 = 4,
     V5 = 5,
-    V6 = 6
+    V6 = 6,
+    V7 = 7
 }

--- a/DMapper.Core/Extensions/MappingExtensions.cs
+++ b/DMapper.Core/Extensions/MappingExtensions.cs
@@ -33,7 +33,8 @@ namespace DMapper.Extensions
                 DMapperVersion.V3 => ReflectionHelper.ReplacePropertiesRecursive_V3(destination, source),
                 DMapperVersion.V4 => ReflectionHelper.ReplacePropertiesRecursive_V4(destination, source),
                 DMapperVersion.V5 => ReflectionHelper.ReplacePropertiesRecursive_V5(destination, source),
-                DMapperVersion.V6 or _=> ReflectionHelper.ReplacePropertiesRecursive_V6(destination, source)
+                DMapperVersion.V6 => ReflectionHelper.ReplacePropertiesRecursive_V6(destination, source),
+                _ => ReflectionHelper.ReplacePropertiesRecursive_V7(destination, source)
             };
 
             return result;
@@ -63,7 +64,8 @@ namespace DMapper.Extensions
                 DMapperVersion.V3 => ReflectionHelper.ReplacePropertiesRecursive_V3(destination, source),
                 DMapperVersion.V4 => ReflectionHelper.ReplacePropertiesRecursive_V4(destination, source),
                 DMapperVersion.V5 => ReflectionHelper.ReplacePropertiesRecursive_V5(destination, source),
-                DMapperVersion.V6 or _ => ReflectionHelper.ReplacePropertiesRecursive_V6(destination, source)
+                DMapperVersion.V6 => ReflectionHelper.ReplacePropertiesRecursive_V6(destination, source),
+                _ => ReflectionHelper.ReplacePropertiesRecursive_V7(destination, source)
             };
         }
 
@@ -160,7 +162,8 @@ namespace DMapper.Extensions
                 DMapperVersion.V3 => ReflectionHelper.ReplacePropertiesRecursive_V3(destination, source),
                 DMapperVersion.V4 => ReflectionHelper.ReplacePropertiesRecursive_V4(destination, source),
                 DMapperVersion.V5 => ReflectionHelper.ReplacePropertiesRecursive_V5(destination, source),
-                DMapperVersion.V6 or _=> ReflectionHelper.ReplacePropertiesRecursive_V6(destination, source)
+                DMapperVersion.V6 => ReflectionHelper.ReplacePropertiesRecursive_V6(destination, source),
+                _ => ReflectionHelper.ReplacePropertiesRecursive_V7(destination, source)
             };
 
             return result;

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Common/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Common/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace DMapper.Helpers;
 

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V1/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V1/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using DMapper.Core.Helpers;
+using DMapper.Core.Helpers;
 
 namespace DMapper.Helpers;
 

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V2/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V2/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using DMapper.Core.Helpers;
+using DMapper.Core.Helpers;
 
 namespace DMapper.Helpers;
 

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V3/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V3/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Reflection;
 using DMapper.Attributes;
 using DMapper.Comparers;

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V4/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V4/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.ComponentModel;
 using System.Reflection;
 using DMapper.Attributes;

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V5/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Deprecated/V5/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using DMapper.Attributes;
 using DMapper.Constants;
 using DMapper.Helpers.Models;

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Latest/V6/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Latest/V6/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -16,6 +16,16 @@ namespace DMapper.Helpers
 {
     public static partial class ReflectionHelper
     {
+        // Caches for mapping dictionaries and converter instances per destination type.
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, Dictionary<string, List<string>>> _mappingCache_V6 = new();
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, Dictionary<string, IDMapperPropertyConverter>> _converterCache_V6 = new();
+
+        /// <summary>Clears the version 6 caches.</summary>
+        public static void ClearV6Caches()
+        {
+            _mappingCache_V6.Clear();
+            _converterCache_V6.Clear();
+        }
         /// <summary>
         /// Performs version 6 mapping between a source and a destination object.
         /// This method:
@@ -60,9 +70,11 @@ namespace DMapper.Helpers
             FlattenResult srcFlatten = ObjectFlattener.Flatten(source, GlobalConstants.DefaultDotSeparator);
             var fixedSrc = srcFlatten.Properties; // alias
 
-            // 2) Build mapping + converter caches
-            Dictionary<string, List<string>> mappingDict = BuildMappingDictionary_V6(typeof(TDestination));
-            var converterCache = BuildConverterCache_V6(typeof(TDestination));
+            // 2) Build mapping + converter caches (cached per destination type)
+            Dictionary<string, List<string>> mappingDict =
+                _mappingCache_V6.GetOrAdd(typeof(TDestination), t => BuildMappingDictionary_V6(t));
+            var converterCache =
+                _converterCache_V6.GetOrAdd(typeof(TDestination), t => BuildConverterCache_V6(t));
 
             // 3) Direct mapping with per‑property converters
             foreach (var mapping in mappingDict)

--- a/DMapper.Core/Helpers/ReflectionHelper_Versions/Latest/V7/ReflectionHelper.cs
+++ b/DMapper.Core/Helpers/ReflectionHelper_Versions/Latest/V7/ReflectionHelper.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DMapper.Constants;
+using DMapper.Converters;
+using DMapper.Helpers.Models;
+
+namespace DMapper.Helpers;
+
+public static partial class ReflectionHelper
+{
+    // Cache mapping delegates per destination type
+    private static readonly ConcurrentDictionary<Type, Action<object, Dictionary<string, FlattenedProperty>>> _delegateCache_V7 = new();
+
+    /// <summary>
+    /// Performs version 7 mapping using cached delegates built from the version 6 mapping information.
+    /// </summary>
+    public static TDestination ReplacePropertiesRecursive_V7<TDestination, TSource>(TDestination destination, TSource source)
+    {
+        FlattenResult srcFlatten = ObjectFlattener.Flatten(source, GlobalConstants.DefaultDotSeparator);
+        var fixedSrc = srcFlatten.Properties;
+
+        var action = _delegateCache_V7.GetOrAdd(typeof(TDestination), BuildDelegate_V7<TDestination>);
+        action(destination, fixedSrc);
+
+        // Reuse existing ComplexBind logic
+        ProcessComplexBindAttributes_V6(source, destination);
+
+        return destination;
+    }
+
+    private static Action<object, Dictionary<string, FlattenedProperty>> BuildDelegate_V7<TDestination>(Type destType)
+    {
+        var mappingDict = _mappingCache_V6.GetOrAdd(destType, t => BuildMappingDictionary_V6(t));
+        var converterCache = _converterCache_V6.GetOrAdd(destType, t => BuildConverterCache_V6(t));
+
+        // Cache property chains for faster access
+        var chainCache = new Dictionary<string, PropertyInfo[]>();
+        PropertyInfo[] GetChain(string destKey)
+        {
+            if (chainCache.TryGetValue(destKey, out var chain))
+                return chain;
+
+            var parts = destKey.Split(GlobalConstants.DefaultDotSeparator);
+            var list = new List<PropertyInfo>();
+            Type current = destType;
+            foreach (var part in parts)
+            {
+                var prop = current.GetProperty(part, BindingFlags.Public | BindingFlags.Instance);
+                if (prop == null)
+                {
+                    list.Clear();
+                    break;
+                }
+                list.Add(prop);
+                current = prop.PropertyType;
+            }
+            chain = list.ToArray();
+            chainCache[destKey] = chain;
+            return chain;
+        }
+
+        void Setter(object dest, string destKey, object value)
+        {
+            var chain = GetChain(destKey);
+            if (chain.Length == 0) return;
+
+            object current = dest;
+            for (int i = 0; i < chain.Length; i++)
+            {
+                var prop = chain[i];
+                bool last = i == chain.Length - 1;
+                if (last)
+                {
+                    AssignValue(prop, current, value);
+                }
+                else
+                {
+                    object next = prop.GetValue(current);
+                    if (next == null)
+                    {
+                        try
+                        {
+                            next = Activator.CreateInstance(prop.PropertyType);
+                            prop.SetValue(current, next);
+                        }
+                        catch
+                        {
+                            return;
+                        }
+                    }
+
+                    current = next;
+                }
+            }
+        }
+
+        return (destObj, src) =>
+        {
+            foreach (var mapping in mappingDict)
+            {
+                string destKey = mapping.Key;
+                foreach (string candidate in mapping.Value)
+                {
+                    if (!src.TryGetValue(candidate, out var srcProp) || srcProp.Value is null)
+                        continue;
+
+                    object valueToAssign = srcProp.Value;
+                    if (converterCache.TryGetValue(destKey, out var conv) && conv != null)
+                    {
+                        valueToAssign = conv.Convert(valueToAssign);
+                    }
+
+                    Setter(destObj, destKey, valueToAssign);
+                    break;
+                }
+            }
+        };
+
+        // Local helper mirrors logic from SetNestedValueDirect_V6 but uses PropertyInfo chain
+        void AssignValue(PropertyInfo prop, object instance, object value)
+        {
+            try
+            {
+                if (typeof(IList).IsAssignableFrom(prop.PropertyType) && value is IEnumerable srcEnum && value is not string)
+                {
+                    Type destElementType = prop.PropertyType.IsArray
+                        ? prop.PropertyType.GetElementType()!
+                        : (prop.PropertyType.IsGenericType
+                            ? prop.PropertyType.GetGenericArguments().First()
+                            : typeof(object));
+
+                    IList destList = CreateAndMapCollection_V6(srcEnum, destElementType);
+                    if (prop.PropertyType.IsArray)
+                    {
+                        Array arr = Array.CreateInstance(destElementType, destList.Count);
+                        destList.CopyTo(arr, 0);
+                        prop.SetValue(instance, arr);
+                    }
+                    else
+                    {
+                        prop.SetValue(instance, destList);
+                    }
+                    return;
+                }
+
+                Type targetType = prop.PropertyType;
+                Type enumType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+                if (enumType.IsEnum)
+                {
+                    if (Enum.TryParse(enumType, value.ToString(), true, out var enumVal))
+                        prop.SetValue(instance, enumVal);
+                    return;
+                }
+
+                if (targetType == value?.GetType() || targetType.IsAssignableFrom(value?.GetType()))
+                {
+                    prop.SetValue(instance, value);
+                    return;
+                }
+
+                if (TrySpecialConvert(value, targetType, out var special))
+                {
+                    prop.SetValue(instance, special);
+                    return;
+                }
+
+                if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    targetType = Nullable.GetUnderlyingType(targetType)!;
+
+                object converted = Convert.ChangeType(value, targetType);
+                prop.SetValue(instance, converted);
+            }
+            catch
+            {
+                // Ignore failed assignments
+            }
+        }
+    }
+}
+

--- a/DMapper.Tests/CachingTests.cs
+++ b/DMapper.Tests/CachingTests.cs
@@ -1,0 +1,38 @@
+using DMapper.Extensions;
+using DMapper.Helpers;
+using Xunit;
+
+namespace DMapper.Tests;
+
+public class CachingTests
+{
+    private class SimpleSource { public int Id { get; set; } }
+    private class SimpleDestination { public int Id { get; set; } }
+
+    [Fact]
+    public void MapTo_ReusesMappingCaches()
+    {
+        ReflectionHelper.ClearV6Caches();
+        var src = new SimpleSource { Id = 1 };
+        src.MapTo<SimpleDestination>(DMapper.Enums.DMapperVersion.V6);
+        int afterFirst = GetMappingCacheCount();
+        src.MapTo<SimpleDestination>(DMapper.Enums.DMapperVersion.V6);
+        int afterSecond = GetMappingCacheCount();
+        Assert.Equal(afterFirst, afterSecond);
+    }
+
+    private static int GetMappingCacheCount()
+    {
+        var field = typeof(ReflectionHelper).GetField("_mappingCache_V6", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        var dict = (System.Collections.IDictionary)field.GetValue(null);
+        return dict.Count;
+    }
+
+    [Fact]
+    public void MapTo_V7_ShouldProduceSameResult()
+    {
+        var src = new SimpleSource { Id = 42 };
+        var dest = src.MapTo<SimpleDestination>(DMapper.Enums.DMapperVersion.V7);
+        Assert.Equal(42, dest.Id);
+    }
+}

--- a/DMapper.Tests/DMapper.Tests.csproj
+++ b/DMapper.Tests/DMapper.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>

--- a/DMapper.Tests/MappingTests.cs
+++ b/DMapper.Tests/MappingTests.cs
@@ -1,4 +1,4 @@
-﻿using DMapper.Extensions;
+using DMapper.Extensions;
 using DMapper.Tests.Models.Attribute_MappingTests.Map_NonNullable_To_NonNullable_ShouldMapCorrectly;
 using DMapper.Tests.Models.Attribute_MappingTests.MapTo_FallbackEnumMapping_ShouldRemainNullForNullableEnum_WhenSourceIsNull;
 using DMapper.Tests.Models.MappingTests.MapTo_AbsoluteBindTo_ShouldMapFullPathPropertyCorrectly;

--- a/DMapper.Tests/Models/Attribute_MappingTests/Map_NonNullable_To_NonNullable_ShouldMapCorrectly/TestModel_21.cs
+++ b/DMapper.Tests/Models/Attribute_MappingTests/Map_NonNullable_To_NonNullable_ShouldMapCorrectly/TestModel_21.cs
@@ -1,4 +1,4 @@
-﻿namespace DMapper.Tests.Models.Attribute_MappingTests.Map_NonNullable_To_NonNullable_ShouldMapCorrectly;
+namespace DMapper.Tests.Models.Attribute_MappingTests.Map_NonNullable_To_NonNullable_ShouldMapCorrectly;
 
 // Define two sample enums with matching values.
 public enum TestEnum21_1


### PR DESCRIPTION
## Summary
- add caching for v6 mapping dictionary and converter cache
- implement delegate-based v7 mapper using cached property chains
- wire up MappingExtensions and version enum for v7
- add basic caching and v7 unit tests
- clean BOM markers from source